### PR TITLE
Fixed class conflict error

### DIFF
--- a/InvokableEvent.cs
+++ b/InvokableEvent.cs
@@ -2,7 +2,7 @@
 
 public class InvokableEvent : InvokableEventBase {
 
-	public Action action;
+	public System.Action action;
 
 	public void Invoke() {
 		action();


### PR DESCRIPTION
Explicitly using System.Action to avoid class conflicts where other Action classes may exist.